### PR TITLE
Clarify Recovery Input as a Fraction

### DIFF
--- a/week2/RO_flowsheet_with_ERD_build.ipynb
+++ b/week2/RO_flowsheet_with_ERD_build.ipynb
@@ -283,9 +283,7 @@
   {
    "cell_type": "markdown",
    "id": "cf81e3a6",
-   "metadata": {
-    "jp-MarkdownHeadingCollapsed": true
-   },
+   "metadata": {},
    "source": [
     "## Step 3: Specify Model\n",
     "\n",


### PR DESCRIPTION
Clarify that the user input for volumetric recovery should be a fraction as opposed to a percentage value.